### PR TITLE
#3: Add `product` function which sums all entries in a numeric array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npm i stat-methods
 3.  [Descriptive statistics](#Descriptive-statistics)
     -   [min](#min)
     -   [max](#max)
+    -   [product](#product)
   
 4.  [Measures of similarity](#Measures-of-similarity)
     -   [covariance](#covariance)
@@ -328,6 +329,16 @@ The maximum is the largest number in the data array.
 
 ```js
 max([2.5, 3.25, -2, 5.75]); // -> 5.75
+```
+
+If the data array is empty or contains a non finite `Number`, the method returns `undefined`.
+
+#### product
+
+Return the product of all entries in a numeric data array.
+
+```js
+product([1, 2, 3, 4]); // -> 24
 ```
 
 If the data array is empty or contains a non finite `Number`, the method returns `undefined`.

--- a/src/descriptive.js
+++ b/src/descriptive.js
@@ -28,7 +28,23 @@ export function max(arr) {
   return result;
 }
 
+/**
+ * Returns the product of all entries in a numeric data array.
+ * @param {Array} arr the data array
+ * @returns {Number} the product of all the data in the array
+ */
+export function product(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) return undefined;
+  let result = 1;
+  for (let i = 0; i < arr.length; i += 1) {
+    if (!Number.isFinite(arr[i])) return undefined;
+    result = result * arr[i];
+  }
+  return result;
+}
+
 export default {
   min,
   max,
+  product,
 };

--- a/src/descriptive.js
+++ b/src/descriptive.js
@@ -38,7 +38,7 @@ export function product(arr) {
   let result = 1;
   for (let i = 0; i < arr.length; i += 1) {
     if (!Number.isFinite(arr[i])) return undefined;
-    result = result * arr[i];
+    result *= arr[i];
   }
   return result;
 }

--- a/test/descriptive.test.js
+++ b/test/descriptive.test.js
@@ -2,6 +2,7 @@ import{ testUndefinedWithNullable } from './utils';
 import {
   min,
   max,
+  product,
 } from '../src/descriptive';
 
 describe('Descriptive Statistics', () => {
@@ -28,4 +29,19 @@ describe('Descriptive Statistics', () => {
     expect(max([3, 2.5, 200, 5.75])).toBe(200);
     testUndefinedWithNullable(max);
   });
+
+  test('Product', () => {
+    expect(product([1,2,3,4,5])).toBe(120);
+    expect(product([2.5, 3.25, 2, 5.75])).toBe(93.4375);
+    expect(product([NaN, 2, 3, 4])).toBeUndefined();
+    expect(product([])).toBeUndefined();
+    expect(product(['a', 2, 3, 4])).toBeUndefined();
+    expect(product(["hello", 3, 4, 5])).toBeUndefined();
+    expect(product(3)).toBeUndefined();
+    expect(product([3])).toBe(3);
+    expect(product([5, 8, 1.2, 0])).toBe(0);
+    expect(product([5, 8, 1.2, null])).toBeUndefined();
+    testUndefinedWithNullable(product);
+  });
+
 });


### PR DESCRIPTION
As per https://github.com/boristane/stat-methods.js/issues/3 - this returns the product of all entries in an array.

It's gone under `Descriptive statistics` as per the original issue but wondered about creating a new module for `aggregates` or something? Thoughts?